### PR TITLE
Sync exclude

### DIFF
--- a/bacchus-sync/debian/changelog
+++ b/bacchus-sync/debian/changelog
@@ -1,3 +1,9 @@
+bacchus-sync (0.5-1) bionic; urgency=medium
+
+  * Excluded *.wdb and .cache from sync
+
+ -- YeonGyu Jeong <81887821@hanmail.net>  Thu, 01 Nov 2018 19:12:51 +0900
+
 bacchus-sync (0.4.2-1) bionic; urgency=medium
 
   * fixed Dependency problem

--- a/bacchus-sync/src/bacchus-sync.vala
+++ b/bacchus-sync/src/bacchus-sync.vala
@@ -187,7 +187,7 @@ class Configuration {
       case StringKey.WRITE:
         return "w";
       case StringKey.RSYNC_EXCLUDE:
-		return "--exclude=.cache/"
+        return "--exclude=.cache/";
       default:
         fatal("Unknown StringKey");
         return "";

--- a/bacchus-sync/src/bacchus-sync.vala
+++ b/bacchus-sync/src/bacchus-sync.vala
@@ -93,6 +93,7 @@ enum StringKey {
   USER,       /* Environment variable key */
   READ,
   WRITE,
+  RSYNC_EXCLUDE,
 }
 
 /**
@@ -185,6 +186,8 @@ class Configuration {
         return "r";
       case StringKey.WRITE:
         return "w";
+      case StringKey.RSYNC_EXCLUDE:
+		return "--exclude=.cache/"
       default:
         fatal("Unknown StringKey");
         return "";
@@ -565,6 +568,7 @@ class DownloadTask : Object {
             Configuration.stringKey(StringKey.RSYNC_AZ),
             Configuration.stringKey(StringKey.RSYNC_DELETE),
             Configuration.stringKey(StringKey.RSYNC_PROGRESS2),
+            Configuration.stringKey(StringKey.RSYNC_EXCLUDE),
             Configuration.stringKey(StringKey.NFS_HOME_OF).printf(userName),
             Configuration.stringKey(StringKey.LOCAL_HOME),
           },
@@ -629,6 +633,7 @@ class UploadTask : Object {
             Configuration.stringKey(StringKey.RSYNC_AZ),
             Configuration.stringKey(StringKey.RSYNC_DELETE),
             Configuration.stringKey(StringKey.RSYNC_PROGRESS2),
+            Configuration.stringKey(StringKey.RSYNC_EXCLUDE),
             Configuration.stringKey(StringKey.LOCAL_HOME_OF).printf(userName),
             Configuration.stringKey(StringKey.NFS_HOME),
           },

--- a/bacchus-sync/src/gdm/PostSession/Default.bacchus-sync.sh
+++ b/bacchus-sync/src/gdm/PostSession/Default.bacchus-sync.sh
@@ -6,6 +6,8 @@ then
   exit 0
 fi
 
+# Evil Xilinx ISE files
+find "$HOME" -name '*.wdb' -type f -delete
 # Domain user: invoke domain user session cleanup
 /usr/bin/bacchus-sync --domain --logout
 


### PR DESCRIPTION
### bacchus-sync 업데이트
* `.cache` 폴더를 동기화 대상에서 제외
* `*.wdb` 파일을 로그아웃 시 삭제